### PR TITLE
Add the pingSenderVersion field to the decoder

### DIFF
--- a/moz_telemetry/io_modules/decoders/moz_telemetry/ping.lua
+++ b/moz_telemetry/io_modules/decoders/moz_telemetry/ping.lua
@@ -478,6 +478,7 @@ function transform_message(hsr)
         msg.Fields.geoCity         = hsr:read_message("Fields[geoCity]")
         msg.Fields.submissionDate  = os.date("%Y%m%d", hsr:read_message("Timestamp") / 1e9)
         msg.Fields.sourceName      = "telemetry"
+        msg.Fields.pingSenderVersion = hsr:read_message("Fields[X-PingSender-Version]")
 
         -- insert geo info if necessary
         if city_db and not msg.Fields.geoCountry then


### PR DESCRIPTION
This will enable storing the pingsender version that comes from the headers of the pings sent with it.

The new header is documented [here](https://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/internals/pingsender.html).